### PR TITLE
Line causing an error when opening quest windows

### DIFF
--- a/PawnUI.lua
+++ b/PawnUI.lua
@@ -2218,7 +2218,7 @@ function PawnUI_OnQuestInfo_ShowRewards()
 	if not PawnCommon.ShowQuestUpgradeAdvisor then return end
 
 	-- Now, get information about this quest.
-	-- local QuestID = C_QuestLog.GetSelectedQuest()
+	local QuestID = GetQuestID()
 	local IsInMap = WorldMapFrame:IsShown()
 	local StaticRewards, RewardChoices
 	local GetLinkFunction, GetRewardInfoFunction, GetChoiceInfoFunction

--- a/PawnUI.lua
+++ b/PawnUI.lua
@@ -2218,7 +2218,7 @@ function PawnUI_OnQuestInfo_ShowRewards()
 	if not PawnCommon.ShowQuestUpgradeAdvisor then return end
 
 	-- Now, get information about this quest.
-	local QuestID = C_QuestLog.GetSelectedQuest()
+	-- local QuestID = C_QuestLog.GetSelectedQuest()
 	local IsInMap = WorldMapFrame:IsShown()
 	local StaticRewards, RewardChoices
 	local GetLinkFunction, GetRewardInfoFunction, GetChoiceInfoFunction


### PR DESCRIPTION
Line of code seems to be unused, commented it out an the error was gone, can't see any negative effect but probably needs further testing.

Originally thought it was a typo as apparently methods in LUA need to be called with ':' so 'C_QuestLog.GetSelectedQuest()' should have been 'C_QuestLog:GetSelectedQuest()' ???

But that didn't work either when I tried it.