### PR TITLE
Retail dodge parry

### DIFF
--- a/UIStrings.lua
+++ b/UIStrings.lua
@@ -3,7 +3,7 @@
 -- © 2006-2020 Green Eclipse.  This mod is released under the Creative Commons Attribution-NonCommercial-NoDerivs 3.0 license.
 -- See Readme.htm for more information.
 
--- 
+--
 -- UI strings
 ------------------------------------------------------------
 
@@ -349,7 +349,7 @@ PawnUIFrame_MrRobotLabel_Text = L.AboutMrRobot
 -- Configuration UI, Help tab
 PawnUIFrame_HelpTab_Text = L.HelpTab
 PawnUIFrame_GettingStartedLabel_Text = L.HelpText
-	
+
 -- Interface Options page
 PawnInterfaceOptionsFrame_OptionsHeaderLabel_Text = L.InterfaceOptionsWelcome
 PawnInterfaceOptionsFrame_OptionsSubHeaderLabel_Text = L.InterfaceOptionsBody

--- a/UIStrings.lua
+++ b/UIStrings.lua
@@ -56,8 +56,8 @@ local PawnStatsUnfiltered =
 	{L.SpellDamage, "SpellDamage", L.SpellDamageInfo, PawnStatNormal, nil, PawnStatClassicOnly},
 	{L.Healing, "Healing", L.HealingInfo, PawnStatNormal, nil, PawnStatClassicOnly},
 	{ITEM_MOD_DEFENSE_SKILL_RATING_SHORT, "DefenseRating", L.DefenseInfo, PawnStatNormal, nil, PawnStatClassicOnly},
-	{ITEM_MOD_DODGE_RATING_SHORT, "DodgeRating", L.DodgeInfo, PawnStatNormal, nil, PawnStatClassicOnly},
-	{ITEM_MOD_PARRY_RATING_SHORT , "ParryRating", L.ParryInfo, PawnStatNormal, nil, PawnStatClassicOnly},
+	{ITEM_MOD_DODGE_RATING_SHORT, "DodgeRating", L.DodgeInfo, PawnStatNormal, nil},
+	{ITEM_MOD_PARRY_RATING_SHORT , "ParryRating", L.ParryInfo, PawnStatNormal, nil},
 	{ITEM_MOD_BLOCK_RATING_SHORT, "BlockRating", L.BlockRatingInfo, PawnStatNormal, nil, PawnStatClassicOnly},
 	{ITEM_MOD_BLOCK_VALUE_SHORT, "BlockValue", L.BlockValueInfo, PawnStatNormal, nil, PawnStatClassicOnly},
 


### PR DESCRIPTION
I found dodge and parry useful on Retail for doing tank stat weights for Herald of the Titans (level 30 Ulduar) gearing.