### PR TITLE
Add ArkInventoryRules Integration

### DIFF
--- a/Pawn.lua
+++ b/Pawn.lua
@@ -380,6 +380,12 @@ function PawnInitialize()
 		LinkWrangler.RegisterCallback("Pawn", PawnLinkWranglerOnTooltip, "refreshcomp")
 	end
 
+    -- ArkInventory integration -- register the pawn upgrade rule
+    if ArkInventoryRules then
+        local arkInventoryModule = ArkInventoryRules:NewModule("Pawn")
+        ArkInventoryRules.Register( arkInventoryModule, "PAWNUPGRADE", ArkInventoryPawnUpgradeRule)
+    end
+
 	-- In-bag upgrade icons
 	if ContainerFrame_UpdateItemUpgradeIcons then
 
@@ -778,6 +784,25 @@ function PawnLinkWranglerOnTooltip(Tooltip, ItemLink)
 	if not Tooltip then return end
 	PawnUpdateTooltip(Tooltip:GetName(), "SetHyperlink", ItemLink)
 	PawnAttachIconToTooltip(Tooltip, false, ItemLink)
+end
+
+-- ArkInventory Rule
+function ArkInventoryPawnUpgradeRule( ... )
+    local fn = "PAWNUPGRADE" -- Rule name for errors
+    if not PawnIsInitialized then VgerCore.Fail("Can't check to see if items are upgrades until Pawn is initialized") return end
+
+    -- Verify that the item string information is loaded and not nil and that it is a valid item before continuing
+    if not ArkInventoryRules.Object.h or ArkInventoryRules.Object.class ~= "item" then return false end
+
+    -- Parse the incoming item and retrieve the data
+    local ac = select( '#', ... )
+    local info = ArkInventory.ObjectInfoArray( ArkInventoryRules.Object.h )
+
+    -- Extract the itemLink from the ArkInventory info object
+    local itemLink = info.info[2]
+
+    -- Use the same logic for determining whether or not an arrow should be shown, for consistency
+    return PawnShouldItemLinkHaveUpgradeArrow(itemLink, true)
 end
 
 -- If debugging is enabled, show a message; otherwise, do nothing.

--- a/Pawn.toc
+++ b/Pawn.toc
@@ -2,7 +2,7 @@
 ## Title: Pawn
 ## Version: 2.4.17
 ## Notes: Pawn helps you compare items and find upgrades.
-## OptionalDependencies: AtlasLoot, EQCompare, EquipCompare, LinkWrangler, MobInfo2, MultiTips, Outfitter
+## OptionalDependencies: AtlasLoot, EQCompare, EquipCompare, LinkWrangler, MobInfo2, MultiTips, Outfitter, ArkInventoryRules
 ## SavedVariables: PawnCommon
 ## SavedVariablesPerCharacter: PawnOptions, PawnMrRobotScaleProviderOptions, PawnClassicScaleProviderOptions
 

--- a/Readme.htm
+++ b/Readme.htm
@@ -258,6 +258,7 @@ working with Pawn, please make sure that you have the latest version of both it
 and Pawn.</p>
 <ul>
 	<li>Ackis Recipe List</li>
+    <li>ArkInventory</li>
 	<li>AtlasLoot</li>
 	<li>Armory</li>
 	<li>CowTip</li>
@@ -278,6 +279,10 @@ and Pawn.</p>
 	<li>tdItemTip</li>
 	<li>tekKompare</li>
 </ul>
+<h3>ArkInventory Rule</h3>
+<p>When you have ArkInventory, ArkInventoryRules, and Pawn enabled, you can use the <code>pawnupgrade()</code> rule in
+ArkInventory to run a Pawn comparison on items in your inventory for sorting. This will return true if the item is
+an upgrade and false if not.</p>
 <h3><span style="text-decoration: underline;">In</span>compatible addons</h3>
 <ul>
 	<li>FreeUI<ul>


### PR DESCRIPTION
Implement an ArkInventory rule `pawnupgrade()` that checks Pawn to see if the item is an upgrade. This will allow users of ArkInventory and Pawn to sort upgrade items into different sections of ArkInventory and even auto-sell non-upgrade gear.