### PR TITLE
Add ArkInventoryRules Integration

### DIFF
--- a/Pawn.toc
+++ b/Pawn.toc
@@ -2,7 +2,7 @@
 ## Title: Pawn
 ## Version: 2.4.17
 ## Notes: Pawn helps you compare items and find upgrades.
-## OptionalDependencies: AtlasLoot, EQCompare, EquipCompare, LinkWrangler, MobInfo2, MultiTips, Outfitter
+## OptionalDependencies: AtlasLoot, EQCompare, EquipCompare, LinkWrangler, MobInfo2, MultiTips, Outfitter, ArkInventoryRules
 ## SavedVariables: PawnCommon
 ## SavedVariablesPerCharacter: PawnOptions, PawnMrRobotScaleProviderOptions, PawnClassicScaleProviderOptions
 

--- a/Readme.htm
+++ b/Readme.htm
@@ -258,6 +258,7 @@ working with Pawn, please make sure that you have the latest version of both it
 and Pawn.</p>
 <ul>
 	<li>Ackis Recipe List</li>
+	<li>ArkInventory</li>
 	<li>AtlasLoot</li>
 	<li>Armory</li>
 	<li>CowTip</li>
@@ -278,6 +279,12 @@ and Pawn.</p>
 	<li>tdItemTip</li>
 	<li>tekKompare</li>
 </ul>
+<h3>ArkInventory Rule</h3>
+<p>When you have ArkInventory, ArkInventoryRules, and Pawn enabled, you can use the <code>pawnupgrade()</code> rule in
+ArkInventory to run a Pawn comparison on items in your inventory for sorting. This will return true if the item is
+an upgrade and false if it is indeterminate or not an upgrade. To determine if something is not an upgrade, use
+<code>pawnnotupgrade()</code>. This rule will return true if the item is definitely not an upgrade, and false if it is
+indeterminate or an upgrade. This can be used for auto-sell rules, such as <code>bind(3) and pawnnotupgrade()</code>.
 <h3><span style="text-decoration: underline;">In</span>compatible addons</h3>
 <ul>
 	<li>FreeUI<ul>


### PR DESCRIPTION
Implement a ArkInventory rules `pawnupgrade()` and `pawnnotupgrade()` that check Pawn to see if the item is an upgrade or not. This will allow users of ArkInventory and Pawn to sort upgrade items into different sections of ArkInventory and even auto-sell non-upgrade gear.