### PR TITLE
added parsing for green affixes "of the Prophet" and "of Healing"

### DIFF
--- a/Localization.lua
+++ b/Localization.lua
@@ -321,6 +321,7 @@ For more information on customizing Pawn, please see the help file (Readme.htm) 
 		["HaventCollectedAppearance"] = "^You haven't collected this appearance$",
 		["Healing"] = "^%+# Healing Spells$",
 		["Healing2"] = "^Equip: Increases healing done by spells and effects by up to #%.$",
+		["Healing3"] = "^%+?# Healing$",
 		["HeirloomLevelRange"] = "^Requires level %d+ to (%d+)",
 		["HeirloomXpBoost"] = "^Equip: Experience gained",
 		["HeirloomXpBoost2"] = "^UNUSED$",

--- a/TooltipParsing.lua
+++ b/TooltipParsing.lua
@@ -306,6 +306,7 @@ PawnRegexes =
 	{L.HolySpellDamage2, "HolySpellDamage"}, -- /pawn compare 20504
 	{L.Healing, "Healing"}, -- /pawn compare item:789::::::2028
 	{L.Healing2, "Healing"}, -- /pawn compare 16947
+	{L.Healing3, "Healing"},  -- /pawn compare item:24593::::::-38:701562918:61
 	{L.SpellPower, "SpellDamage", 1, PawnMultipleStatsExtract, "Healing", 1, PawnMultipleStatsExtract}, -- enchantments
 	{PawnGameConstant(EMPTY_SOCKET_RED), "RedSocket", 1, PawnMultipleStatsFixed},
 	{PawnGameConstant(EMPTY_SOCKET_YELLOW), "YellowSocket", 1, PawnMultipleStatsFixed},


### PR DESCRIPTION
"+# Healing" can appear on various Azeroth and Outland items, likely newly introduced for burning crusade classic.  Example affixes:
of Healing
of The Prophet

Example items these affixes can spawn for:
https://tbc.wowhead.com/item=24707/haaleshi-pauldrons
https://tbc.wowhead.com/item=789/stout-battlehammer
https://tbc.wowhead.com/item=24593/fireheart-skullcap