### PR TITLE
Update Pawn.lua

### DIFF
--- a/Pawn.lua
+++ b/Pawn.lua
@@ -2618,7 +2618,7 @@ function PawnGetItemValue(Item, ItemLevel, SocketBonus, ScaleName, DebugMessages
 				ThisValue = ScaleValues.MetaSocketEffect
 				if ThisValue then
 					Stat = "MetaSocketEffect"
-					Quantity = Item[Stat]
+					Quantity = Item[Stat] or 0
 					TotalSocketValue = TotalSocketValue + Quantity * ThisValue
 					if DebugMessages then PawnDebugMessage(format(PawnLocal.ValueCalculationMessage, Quantity, Stat, ThisValue, Quantity * ThisValue)) end
 				end


### PR DESCRIPTION
Should fix this error related to sockets

```
232x Pawn\Pawn-2.5.10.lua:2622: attempt to perform arithmetic on local 'Quantity' (a nil value)
[string "@Pawn\Pawn-2.5.10.lua"]:2622: in function `PawnGetItemValue'
[string "@Pawn\Pawn-2.5.10.lua"]:1654: in function `PawnGetAllItemValues'
[string "@Pawn\Pawn-2.5.10.lua"]:1474: in function `PawnRecalculateItemValuesIfNecessary'
[string "@Pawn\Pawn-2.5.10.lua"]:1348: in function `PawnGetItemData'
[string "@Pawn\Pawn-2.5.10.lua"]:5570: in function `PawnShouldItemLinkHaveUpgradeArrow'
[string "@Pawn\PawnUI.lua"]:2251: in function <Pawn\PawnUI.lua:2243>
[string "=[C]"]: in function `LootHistoryFrame_UpdateItemFrame'
[string "@FrameXML\LootHistory.lua"]:68: in function <FrameXML\LootHistory.lua:53>
[string "=[C]"]: in function `LootHistoryFrame_FullUpdate'
[string "@FrameXML\LootHistory.lua"]:28: in function <FrameXML\LootHistory.lua:26>
```