### PR TITLE
deDE: add missing CritRating2

### DIFF
--- a/Localization.deDE.lua
+++ b/Localization.deDE.lua
@@ -274,7 +274,7 @@ Weitere Informationen zur Anpassung von Pawn findet ihr in der Hilfedatei (Readm
 		["Crit2"] = "^UNUSED$",
 		["CritPercent"] = "^Anlegen: Erhöht Eure Chance, einen kritischen Treffer zu erzielen, um #%%%.$",
 		["CritRating"] = "^Anlegen: Erhöht Eure kritische Trefferwertung um #%.$",
-		["CritRating2"] = "^UNUSED$",
+		["CritRating2"] = "^Anlegen: Erhöht die kritische Trefferwertung um #%.$",
 		["CritRatingShort"] = "^%+?# Kritische Trefferwertung$",
 		["Crossbow"] = "^Armbrust$",
 		["Dagger"] = "^Dolch$",


### PR DESCRIPTION
Blizz slightly changed the wording for crit rating on some of the TBC items in the german localization.
Added the correct term as tested locally with my german client.