### PR TITLE
build(deps-dev): bump actions/checkout from 2 to 3

### DIFF
--- a/.github/workflows/package-addon.yml
+++ b/.github/workflows/package-addon.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get name of addon
       id: init


### PR DESCRIPTION
Bump bump actions/checkout GitHub Action from 2 to 3. Main change is it is now using Node 16 instead of 12.