### PR TITLE
Add missing french translation for armor penetration stat

### DIFF
--- a/Localization.frFR.lua
+++ b/Localization.frFR.lua
@@ -263,7 +263,7 @@ Pour plus d'information sur la Personnalisation de Pawn, regarder le fichier d'a
 		["Armor2"] = "^UNUSED$",
 		["ArmorPenetration"] = "^Équipé : Vos attaques ignorent # points de l'armure de votre adversaire%.$",
 		["ArmorPenetrationRating"] = "^Équipé : Augmente de # le score de pénétration d'armure%.$",
-		["ArmorPenetrationRating2"] = "^UNUSED$",
+		["ArmorPenetrationRating2"] = "^Équipé : Augmente de # la pénétration d'armure%.$",
 		["ArmorPenetrationShort"] = "^%+?# au score de pénétration d'armure$",
 		["Avoidance"] = "^%+# Évitement$",
 		["Axe"] = "^Hache$",


### PR DESCRIPTION
WOTLK - French client

Fix a bug where armor penetration of a gear piece is ignored by Pawn because it is missing one of the french translation to detect it

Exemple of item with the text written this way : 
https://www.wowhead.com/wotlk/fr/item=45453/etreinte-glac%C3%A9e-de-lhiver

Équipé : Augmente de 86 la pénétration d'armure.