### PR TITLE
GetItemIcon generates LUA error

### DIFF
--- a/Pawn.lua
+++ b/Pawn.lua
@@ -3341,7 +3341,7 @@ function PawnAttachIconToTooltip(Tooltip, AttachAbove, ItemLink)
 			_, ItemLink = Tooltip:GetItem()
 		end
 		if ItemLink then
-			TextureName = C_Item.GetItemIcon(ItemLink)
+			TextureName = C_Item.GetItemIconByID(ItemLink)
 		end
 	end
 


### PR DESCRIPTION
GetItemIcon split into 2. Old one does not accept links.