### PR TITLE
Update Localization.ruRU.lua

### DIFF
--- a/Localization.ruRU.lua
+++ b/Localization.ruRU.lua
@@ -779,10 +779,6 @@ if VgerCore.IsBurningCrusade or VgerCore.IsWrath or VgerCore.IsCataclysm then
 	PawnLocal.ThousandsSeparator = ","
 end
 
-if VgerCore.IsCataclysm then
-	PawnLocal.TooltipParsing.Mastery = "^%+?# Искусность$"
-end
-
 end
 
 if GetLocale() == "ruRU" then


### PR DESCRIPTION
Fix Mastery parsing for ruRU

Normal translation works fine both in Cata and Retail, thus no need to override it for Cata.

Example of tooltip with Mastery in Cata:
![image](https://github.com/user-attachments/assets/2f458c93-96bf-4654-9a1e-5e6bbb189b03)

Example of tooltip with Mastery in Retail:
![image](https://github.com/user-attachments/assets/4d704cab-9a39-4437-af82-c954129a2ff1)

