### PR TITLE
Fix durability Regex for tooltip parsing

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -73,7 +73,9 @@ end
 
 -- Turns a game constant with "%d" placeholders into a pattern that can be used to match that string.
 function PawnGameConstantIgnoredNumberPlaceholder(Text)
-	return gsub(PawnGameConstant(Text), "%%%%d", "%%d+")
+	-- gsub may return second result - amount of substitutions. Just ignore it.
+	local value, _ = gsub(PawnGameConstant(Text), "%%%%d", "%%d+")
+	return value
 end
 
 -- Escapes a string so that it can be more easily printed.


### PR DESCRIPTION
string.gsub has two return values: processed string and amount of substitutions made. 

This result in a table returned to PawnRegexes:

```
[1]="^Durability: %d+ / %d+$",
[2]=2
```

Thus PawnLookForSingleStat will treat it as a Stat:

https://github.com/VgerMods/Pawn/blob/bb341eeebe9a8ebeb0499554766b6a7a9984271f/Pawn.lua#L2540C1-L2544C37
