### PR TITLE
Updated ToC for TBC

### DIFF
--- a/Pawn.toc
+++ b/Pawn.toc
@@ -1,6 +1,6 @@
-﻿## Interface: 110207, 120000, 120001
+﻿## Interface: 11508, 20505, 50503, 110207, 120001
 ## Title: Pawn
-## Version: 2.13.1
+## Version: @project-version@
 ## Notes: Pawn helps you compare items and find upgrades.
 ## OptionalDependencies: Ace3, ArkInventoryRules, AtlasLoot, EQCompare, EquipCompare, LinkWrangler, MobInfo2, MultiTips, Outfitter
 ## SavedVariables: PawnCommon
@@ -21,6 +21,7 @@
 ## Category-zhTW: 裝備
 
 ## X-Wago-ID: R4N2k46L
+## X-Curse-Project-ID: 1128926
 
 VgerCore\VgerCore.lua
 


### PR DESCRIPTION
Doesn't really feel like you're using this though... there weren't any Classic Interface IDs in there.

Anyway, just a nudge that the Interface needs to be updated.

Current for Classic Era is 1.15.8 and Current for TBC is 2.5.5.

https://wago.tools/

Also added version variable powered off your GitHub Actions release process, will shave a few seconds off a deploy. (=

Cheers!