### PR TITLE
Fix: Remove forced :Show() in EmbeddedItemTooltip hook causing Secret Value taint crash (12.0 / Midnight)

### DIFF
--- a/Pawn.lua
+++ b/Pawn.lua
@@ -334,7 +334,15 @@ function PawnInitialize()
 				local ItemName, ItemTexture = GetQuestLogRewardInfo(QuestLogIndex, QuestID)
 				if ItemName and ItemTexture then
 					PawnUpdateTooltip(self.Tooltip:GetName(), "SetQuestLogItem", "reward", QuestLogIndex, QuestID, ...)
-					self.Tooltip:Show() -- resizes the tooltip's boundaries in case our annotation made it wider
+					-- Midnight / 12.0:
+					-- Forcing :Show() here can trigger EmbeddedItemTooltip_UpdateSize()
+					-- in a tainted execution path, which causes:
+					-- "attempt to perform arithmetic on a secret number value (tainted by 'Pawn')"
+					--
+					-- Blizzard already handles tooltip layout after SetItemByQuestReward.
+					-- Do NOT force a Show() call here to avoid secret-value taint crashes.
+					--
+					-- self.Tooltip:Show()
 				end
 			end
 		end)
@@ -4375,9 +4383,9 @@ function PawnFindOptimalReforgingCore(ScaleName, Scale, Values, Stats, NoInstruc
 			return 0
 		end
 	end
-	
+
 	-- Now, find the stat to reforge FROM.
-	local ReforgeFrom = { }	
+	local ReforgeFrom = { }
 	local BestReforgeDelta = 0
 	local SuggestedCappedStat = false
 	for _, Stat in pairs(PawnReforgeableStats) do


### PR DESCRIPTION
## Problem

Hovering World Quest rewards on the map can trigger:

    GameTooltip.lua:754: attempt to perform arithmetic on a secret number value (tainted by 'Pawn')

Call chain:
EmbeddedItemTooltip_SetItemByQuestReward
 → PawnUpdateTooltip
 → self.Tooltip:Show()
 → OnSizeChanged
 → EmbeddedItemTooltip_UpdateSize
 → arithmetic on secret value (tainted context)

In 12.0 (Midnight), Blizzard introduced Secret Values which cannot be used in arithmetic in tainted execution paths.

Forcing self.Tooltip:Show() from inside a hooksecurefunc() callback can place the tooltip in a tainted state. When Blizzard later recalculates layout inside EmbeddedItemTooltip_UpdateSize(), arithmetic on a secret value throws a Lua error.

## Root Cause

The forced Show() call triggers OnSizeChanged and layout recalculation inside a tainted context.

Blizzard already handles layout and sizing after SetItemByQuestReward, so the manual Show() is unnecessary.

## Fix

Remove the forced self.Tooltip:Show() call.

This avoids the taint propagation and resolves the secret-number arithmetic crash.

## Repro

1. Enable Pawn
2. Hover a World Quest on the map
3. Lua error occurs

After this change:
No error.
Tooltip renders correctly.
